### PR TITLE
Ajuste no metodo de bloqueio e no respectivo teste

### DIFF
--- a/src/Blocker/Request.php
+++ b/src/Blocker/Request.php
@@ -46,7 +46,7 @@ class Request implements Allower
     /**
      * @return HttpFoundation\Response
      */
-    public function sendBlockedResponse()
+    public function block()
     {
         $response = new HttpFoundation\Response();
         $response->setStatusCode(HttpFoundation\Response::HTTP_PRECONDITION_FAILED);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,2 @@
 <?php
-echo __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/unit/src/Blocker/RequestTest.php
+++ b/tests/unit/src/Blocker/RequestTest.php
@@ -53,11 +53,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         new \Dafiti\Blocker\Request($domains);
     }
 
-    public function testSendBlockedResponseShouldReturnResponseWith412StatusCode()
+    public function testBlockShouldReturn412StatusCode()
     {
         $domains = [".dafiti.com.br", ".dafitisports.com.br", ".grendene.com.br"];
         $blocker = new \Dafiti\Blocker\Request($domains);
-        $result = $blocker->sendBlockedResponse();
+        $result = $blocker->block();
         $expected = \Symfony\Component\HttpFoundation\Response::HTTP_PRECONDITION_FAILED;
         $this->assertEquals($expected, $result->getStatusCode());
     }


### PR DESCRIPTION
- Alteração do método sendBlockedResponse() para block()
- Ajustes no teste unitário do block()
- Remoção do echo do bootstrap