### PR TITLE
Inclusao de novo teste unitario para o metodo isAllowed

### DIFF
--- a/tests/unit/src/Blocker/RequestTest.php
+++ b/tests/unit/src/Blocker/RequestTest.php
@@ -62,4 +62,15 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getStatusCode());
     }
 
+    public function testIsAllowedWithNoRefererShouldReturnFalse()
+    {
+        $domains = [".dafiti.com.br"];
+        $_SERVER["HTTP_REFERER"] = "";
+        $blocker = new \Dafiti\Blocker\Request($domains);
+        $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+        $result = $blocker->isAllowed($request);
+
+        $this->assertFalse($result);
+    }
+
 }


### PR DESCRIPTION
- Novo teste unitário criado para validar o return false, caso o referer nao seja passado.